### PR TITLE
fix(i18n): localize chart axis & tooltip labels via Intl.DateTimeFormat

### DIFF
--- a/src/components/statistics/DeliveryTimelineChart.tsx
+++ b/src/components/statistics/DeliveryTimelineChart.tsx
@@ -69,7 +69,7 @@ export function DeliveryTimelineChart({ data }: DeliveryTimelineChartProps) {
               fontWeight: 600,
             }}
             formatter={(value) => [t('deliveriesCount', { value: String(value) }), t('count')]}
-            labelFormatter={formatMonth}
+            labelFormatter={(label) => formatMonth(label as string)}
             cursor={{ fill: 'hsl(var(--muted))', opacity: 0.3 }}
           />
           <Bar

--- a/src/components/statistics/DeliveryTimelineChart.tsx
+++ b/src/components/statistics/DeliveryTimelineChart.tsx
@@ -1,7 +1,8 @@
 'use client'
 
+import { useMemo } from 'react'
 import { motion } from 'framer-motion'
-import { useTranslations } from 'next-intl'
+import { useTranslations, useLocale } from 'next-intl'
 import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip, CartesianGrid } from 'recharts'
 
 interface DeliveryTimelineChartProps {
@@ -10,6 +11,16 @@ interface DeliveryTimelineChartProps {
 
 export function DeliveryTimelineChart({ data }: DeliveryTimelineChartProps) {
   const t = useTranslations('statistics')
+  const locale = useLocale()
+
+  const formatMonth = useMemo(() => {
+    const fmt = new Intl.DateTimeFormat(locale, { month: 'short', year: 'numeric' })
+    return (key: string) => {
+      const [y, m] = key.split('-')
+      return fmt.format(new Date(parseInt(y), parseInt(m) - 1))
+    }
+  }, [locale])
+
   if (data.length === 0) {
     return (
       <div className="flex items-center justify-center h-[300px] text-muted-foreground">
@@ -43,6 +54,7 @@ export function DeliveryTimelineChart({ data }: DeliveryTimelineChartProps) {
             tick={{ className: 'fill-foreground' }}
             tickLine={{ className: 'stroke-muted-foreground' }}
             axisLine={{ className: 'stroke-muted-foreground' }}
+            tickFormatter={formatMonth}
           />
           <YAxis
             className="text-xs"
@@ -65,6 +77,7 @@ export function DeliveryTimelineChart({ data }: DeliveryTimelineChartProps) {
               fontWeight: 600,
             }}
             formatter={(value) => [t('deliveriesCount', { value: String(value) }), t('count')]}
+            labelFormatter={formatMonth}
             cursor={{ fill: 'hsl(var(--muted))', opacity: 0.3 }}
           />
           <Bar

--- a/src/components/statistics/DeliveryTimelineChart.tsx
+++ b/src/components/statistics/DeliveryTimelineChart.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { useMemo } from 'react'
 import { motion } from 'framer-motion'
-import { useTranslations, useLocale } from 'next-intl'
+import { useTranslations } from 'next-intl'
 import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip, CartesianGrid } from 'recharts'
+import { useMonthKeyFormatter } from '@/hooks/useMonthKeyFormatter'
 
 interface DeliveryTimelineChartProps {
   data: { month: string; count: number }[]
@@ -11,15 +11,7 @@ interface DeliveryTimelineChartProps {
 
 export function DeliveryTimelineChart({ data }: DeliveryTimelineChartProps) {
   const t = useTranslations('statistics')
-  const locale = useLocale()
-
-  const formatMonth = useMemo(() => {
-    const fmt = new Intl.DateTimeFormat(locale, { month: 'short', year: 'numeric' })
-    return (key: string) => {
-      const [y, m] = key.split('-')
-      return fmt.format(new Date(parseInt(y), parseInt(m) - 1))
-    }
-  }, [locale])
+  const formatMonth = useMonthKeyFormatter()
 
   if (data.length === 0) {
     return (

--- a/src/components/statistics/DeliveryTrendChart.tsx
+++ b/src/components/statistics/DeliveryTrendChart.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { useMemo } from 'react'
-import { useTranslations, useLocale } from 'next-intl'
+import { useTranslations } from 'next-intl'
 import { Order } from '@/lib/types'
 import { calculateDeliveryTrend } from '@/lib/prediction'
+import { useMonthKeyFormatter } from '@/hooks/useMonthKeyFormatter'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { TrendingDown, TrendingUp, Minus } from 'lucide-react'
@@ -24,17 +25,9 @@ interface DeliveryTrendChartProps {
 export function DeliveryTrendChart({ orders }: DeliveryTrendChartProps) {
   const t = useTranslations('trend')
   const tc = useTranslations('common')
-  const locale = useLocale()
+  const formatMonth = useMonthKeyFormatter()
 
   const trend = useMemo(() => calculateDeliveryTrend(orders), [orders])
-
-  const formatMonth = useMemo(() => {
-    const fmt = new Intl.DateTimeFormat(locale, { month: 'short', year: 'numeric' })
-    return (key: string) => {
-      const [y, m] = key.split('-')
-      return fmt.format(new Date(parseInt(y), parseInt(m) - 1))
-    }
-  }, [locale])
 
   if (!trend || trend.monthlyAverages.length < 3) return null
 

--- a/src/components/statistics/DeliveryTrendChart.tsx
+++ b/src/components/statistics/DeliveryTrendChart.tsx
@@ -82,7 +82,7 @@ export function DeliveryTrendChart({ orders }: DeliveryTrendChartProps) {
               <Tooltip
                 contentStyle={{ borderRadius: '8px', fontSize: '12px' }}
                 formatter={(value) => [`${value} ${tc('days')}`, t('avgDeliveryTime')]}
-                labelFormatter={formatMonth}
+                labelFormatter={(label) => formatMonth(label as string)}
               />
               <Area
                 type="monotone"

--- a/src/components/statistics/DeliveryTrendChart.tsx
+++ b/src/components/statistics/DeliveryTrendChart.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useMemo } from 'react'
-import { useTranslations } from 'next-intl'
+import { useTranslations, useLocale } from 'next-intl'
 import { Order } from '@/lib/types'
 import { calculateDeliveryTrend } from '@/lib/prediction'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
@@ -24,8 +24,17 @@ interface DeliveryTrendChartProps {
 export function DeliveryTrendChart({ orders }: DeliveryTrendChartProps) {
   const t = useTranslations('trend')
   const tc = useTranslations('common')
+  const locale = useLocale()
 
   const trend = useMemo(() => calculateDeliveryTrend(orders), [orders])
+
+  const formatMonth = useMemo(() => {
+    const fmt = new Intl.DateTimeFormat(locale, { month: 'short', year: 'numeric' })
+    return (key: string) => {
+      const [y, m] = key.split('-')
+      return fmt.format(new Date(parseInt(y), parseInt(m) - 1))
+    }
+  }, [locale])
 
   if (!trend || trend.monthlyAverages.length < 3) return null
 
@@ -75,11 +84,12 @@ export function DeliveryTrendChart({ orders }: DeliveryTrendChartProps) {
                 </linearGradient>
               </defs>
               <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
-              <XAxis dataKey="month" tick={{ fontSize: 11 }} />
+              <XAxis dataKey="monthKey" tick={{ fontSize: 11 }} tickFormatter={formatMonth} />
               <YAxis tick={{ fontSize: 11 }} label={{ value: tc('days'), angle: -90, position: 'insideLeft', style: { fontSize: 11 } }} />
               <Tooltip
                 contentStyle={{ borderRadius: '8px', fontSize: '12px' }}
                 formatter={(value) => [`${value} ${tc('days')}`, t('avgDeliveryTime')]}
+                labelFormatter={formatMonth}
               />
               <Area
                 type="monotone"

--- a/src/components/statistics/OrdersTimelineChart.tsx
+++ b/src/components/statistics/OrdersTimelineChart.tsx
@@ -1,7 +1,8 @@
 'use client'
 
+import { useMemo } from 'react'
 import { motion } from 'framer-motion'
-import { useTranslations } from 'next-intl'
+import { useTranslations, useLocale } from 'next-intl'
 import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip, CartesianGrid } from 'recharts'
 
 interface OrdersTimelineChartProps {
@@ -10,6 +11,16 @@ interface OrdersTimelineChartProps {
 
 export function OrdersTimelineChart({ data }: OrdersTimelineChartProps) {
   const t = useTranslations('statistics')
+  const locale = useLocale()
+
+  const formatMonth = useMemo(() => {
+    const fmt = new Intl.DateTimeFormat(locale, { month: 'short', year: 'numeric' })
+    return (key: string) => {
+      const [y, m] = key.split('-')
+      return fmt.format(new Date(parseInt(y), parseInt(m) - 1))
+    }
+  }, [locale])
+
   if (data.length === 0) {
     return (
       <div className="flex items-center justify-center h-[300px] text-muted-foreground">
@@ -43,6 +54,7 @@ export function OrdersTimelineChart({ data }: OrdersTimelineChartProps) {
             tick={{ className: 'fill-foreground' }}
             tickLine={{ className: 'stroke-muted-foreground' }}
             axisLine={{ className: 'stroke-muted-foreground' }}
+            tickFormatter={formatMonth}
           />
           <YAxis
             className="text-xs"
@@ -65,6 +77,7 @@ export function OrdersTimelineChart({ data }: OrdersTimelineChartProps) {
               fontWeight: 600,
             }}
             formatter={(value) => [t('ordersCount', { value: String(value) }), t('count')]}
+            labelFormatter={formatMonth}
             cursor={{ fill: 'hsl(var(--muted))', opacity: 0.3 }}
           />
           <Bar

--- a/src/components/statistics/OrdersTimelineChart.tsx
+++ b/src/components/statistics/OrdersTimelineChart.tsx
@@ -69,7 +69,7 @@ export function OrdersTimelineChart({ data }: OrdersTimelineChartProps) {
               fontWeight: 600,
             }}
             formatter={(value) => [t('ordersCount', { value: String(value) }), t('count')]}
-            labelFormatter={formatMonth}
+            labelFormatter={(label) => formatMonth(label as string)}
             cursor={{ fill: 'hsl(var(--muted))', opacity: 0.3 }}
           />
           <Bar

--- a/src/components/statistics/OrdersTimelineChart.tsx
+++ b/src/components/statistics/OrdersTimelineChart.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { useMemo } from 'react'
 import { motion } from 'framer-motion'
-import { useTranslations, useLocale } from 'next-intl'
+import { useTranslations } from 'next-intl'
 import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip, CartesianGrid } from 'recharts'
+import { useMonthKeyFormatter } from '@/hooks/useMonthKeyFormatter'
 
 interface OrdersTimelineChartProps {
   data: { month: string; count: number }[]
@@ -11,15 +11,7 @@ interface OrdersTimelineChartProps {
 
 export function OrdersTimelineChart({ data }: OrdersTimelineChartProps) {
   const t = useTranslations('statistics')
-  const locale = useLocale()
-
-  const formatMonth = useMemo(() => {
-    const fmt = new Intl.DateTimeFormat(locale, { month: 'short', year: 'numeric' })
-    return (key: string) => {
-      const [y, m] = key.split('-')
-      return fmt.format(new Date(parseInt(y), parseInt(m) - 1))
-    }
-  }, [locale])
+  const formatMonth = useMonthKeyFormatter()
 
   if (data.length === 0) {
     return (

--- a/src/components/statistics/VinWeekdayChart.tsx
+++ b/src/components/statistics/VinWeekdayChart.tsx
@@ -76,7 +76,7 @@ export function VinWeekdayChart({ data }: VinWeekdayChartProps) {
               fontWeight: 600,
             }}
             formatter={(value) => [t('vinWeekdayCount', { value: String(value) }), t('count')]}
-            labelFormatter={formatWeekday}
+            labelFormatter={(label) => formatWeekday(label as number)}
             cursor={{ fill: 'hsl(var(--muted))', opacity: 0.3 }}
           />
           <Bar

--- a/src/components/statistics/VinWeekdayChart.tsx
+++ b/src/components/statistics/VinWeekdayChart.tsx
@@ -1,16 +1,23 @@
 'use client'
 
+import { useMemo } from 'react'
 import { motion } from 'framer-motion'
-import { useTranslations } from 'next-intl'
+import { useTranslations, useLocale } from 'next-intl'
 import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip, CartesianGrid } from 'recharts'
 
 interface VinWeekdayChartProps {
-  data: { name: string; count: number }[]
+  data: { dayOfWeek: number; count: number }[]
 }
 
 export function VinWeekdayChart({ data }: VinWeekdayChartProps) {
   const t = useTranslations('statistics')
+  const locale = useLocale()
   const totalVins = data.reduce((sum, d) => sum + d.count, 0)
+
+  const formatWeekday = useMemo(() => {
+    const fmt = new Intl.DateTimeFormat(locale, { weekday: 'short' })
+    return (dayOfWeek: number) => fmt.format(new Date(2025, 0, 5 + dayOfWeek))
+  }, [locale])
 
   if (totalVins < 5) {
     return (
@@ -40,11 +47,12 @@ export function VinWeekdayChart({ data }: VinWeekdayChartProps) {
           </defs>
           <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
           <XAxis
-            dataKey="name"
+            dataKey="dayOfWeek"
             className="text-xs"
             tick={{ className: 'fill-foreground' }}
             tickLine={{ className: 'stroke-muted-foreground' }}
             axisLine={{ className: 'stroke-muted-foreground' }}
+            tickFormatter={formatWeekday}
           />
           <YAxis
             className="text-xs"
@@ -68,6 +76,7 @@ export function VinWeekdayChart({ data }: VinWeekdayChartProps) {
               fontWeight: 600,
             }}
             formatter={(value) => [t('vinWeekdayCount', { value: String(value) }), t('count')]}
+            labelFormatter={formatWeekday}
             cursor={{ fill: 'hsl(var(--muted))', opacity: 0.3 }}
           />
           <Bar

--- a/src/hooks/useMonthKeyFormatter.ts
+++ b/src/hooks/useMonthKeyFormatter.ts
@@ -1,0 +1,16 @@
+'use client'
+
+import { useMemo } from 'react'
+import { useLocale } from 'next-intl'
+
+export function useMonthKeyFormatter() {
+  const locale = useLocale()
+
+  return useMemo(() => {
+    const fmt = new Intl.DateTimeFormat(locale, { month: 'short', year: 'numeric' })
+    return (key: string) => {
+      const [y, m] = key.split('-')
+      return fmt.format(new Date(parseInt(y), parseInt(m) - 1))
+    }
+  }, [locale])
+}

--- a/src/lib/prediction.ts
+++ b/src/lib/prediction.ts
@@ -33,7 +33,7 @@ export interface DeliveryPrediction {
 }
 
 export interface DeliveryTrend {
-  monthlyAverages: { monthKey: string; month: string; avgDays: number; medianDays: number; count: number }[]
+  monthlyAverages: { monthKey: string; avgDays: number; medianDays: number; count: number }[]
   currentTrend: 'accelerating' | 'decelerating' | 'stable'
   trendChangePercent: number
 }
@@ -237,11 +237,8 @@ export function calculateDeliveryTrend(orders: Order[]): DeliveryTrend | null {
     const days = monthMap[month]
     const avg = Math.round(days.reduce((s, d) => s + d, 0) / days.length)
     const med = median(days)
-    const [year, m] = month.split('-')
-    const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
     return {
       monthKey: month,
-      month: `${monthNames[parseInt(m) - 1]} ${year}`,
       avgDays: avg,
       medianDays: med,
       count: days.length,

--- a/src/lib/prediction.ts
+++ b/src/lib/prediction.ts
@@ -33,7 +33,7 @@ export interface DeliveryPrediction {
 }
 
 export interface DeliveryTrend {
-  monthlyAverages: { month: string; avgDays: number; medianDays: number; count: number }[]
+  monthlyAverages: { monthKey: string; month: string; avgDays: number; medianDays: number; count: number }[]
   currentTrend: 'accelerating' | 'decelerating' | 'stable'
   trendChangePercent: number
 }
@@ -240,6 +240,7 @@ export function calculateDeliveryTrend(orders: Order[]): DeliveryTrend | null {
     const [year, m] = month.split('-')
     const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
     return {
+      monthKey: month,
       month: `${monthNames[parseInt(m) - 1]} ${year}`,
       avgDays: avg,
       medianDays: med,

--- a/src/lib/statistics.ts
+++ b/src/lib/statistics.ts
@@ -293,8 +293,7 @@ export function calculateDaysBetween(startDateStr: string | null, endDateStr: st
 }
 
 function getMonthKey(date: Date): string {
-  const months = ['Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez']
-  return `${months[date.getMonth()]} ${date.getFullYear()}`
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`
 }
 
 export function calculateStatistics(orders: Order[], period?: StatsPeriod, vehicleType?: VehicleType): OrderStatistics {

--- a/src/lib/statistics.ts
+++ b/src/lib/statistics.ts
@@ -574,11 +574,12 @@ export function calculateStatistics(orders: Order[], period?: StatsPeriod, vehic
     .sort((a, b) => b.count - a.count)
 
   // VIN weekday distribution
-  const weekdayCounts = [0, 0, 0, 0, 0, 0, 0]
+  const weekdayCounts = [0, 0, 0, 0, 0, 0, 0] // index 0=Sun … 6=Sat
   filteredOrders.forEach(order => {
     const date = parseGermanDate(order.vinReceivedDate)
     if (date) weekdayCounts[date.getDay()]++
   })
+  // Reorder: Mon(1)…Sun(0)
   const vinWeekdayDistribution = [1, 2, 3, 4, 5, 6, 0].map(i => ({
     dayOfWeek: i,
     count: weekdayCounts[i],

--- a/src/lib/statistics.ts
+++ b/src/lib/statistics.ts
@@ -64,7 +64,7 @@ export interface OrderStatistics {
   seatsDistribution: { name: string; count: number; fill: string }[]
   colorDistribution: { name: string; count: number; fill: string }[]
   deliveryLocationDistribution: { name: string; count: number; fill: string }[]
-  vinWeekdayDistribution: { name: string; count: number }[]
+  vinWeekdayDistribution: { dayOfWeek: number; count: number }[]
   countryDeliveryStats: { country: string; avgDays: number; medianDays: number; count: number }[]
   tostOrders: number
   manualOrders: number
@@ -573,16 +573,14 @@ export function calculateStatistics(orders: Order[], period?: StatsPeriod, vehic
     }))
     .sort((a, b) => b.count - a.count)
 
-  // VIN weekday distribution (Mon–Sun)
-  const WEEKDAY_NAMES = ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa']
-  const weekdayCounts = [0, 0, 0, 0, 0, 0, 0] // index 0=Sun … 6=Sat
+  // VIN weekday distribution
+  const weekdayCounts = [0, 0, 0, 0, 0, 0, 0]
   filteredOrders.forEach(order => {
     const date = parseGermanDate(order.vinReceivedDate)
     if (date) weekdayCounts[date.getDay()]++
   })
-  // Reorder: Mon(1)…Sun(0)
   const vinWeekdayDistribution = [1, 2, 3, 4, 5, 6, 0].map(i => ({
-    name: WEEKDAY_NAMES[i],
+    dayOfWeek: i,
     count: weekdayCounts[i],
   }))
 


### PR DESCRIPTION
- Localize month labels on the orders & deliveries timeline charts
- Localize month labels on the delivery trend chart
- Localize weekday labels on the VIN weekday chart
- Switch from hardcoded German month/weekday arrays to `Intl.DateTimeFormat` using the active locale
- Extract the shared `useMonthKeyFormatter` hook to remove duplication across the three monthly charts