### PR TITLE
fix(i18n): localize config distribution labels on stats tabs

### DIFF
--- a/src/components/statistics/StatisticsDashboard.tsx
+++ b/src/components/statistics/StatisticsDashboard.tsx
@@ -127,6 +127,12 @@ export function StatisticsDashboard({ orders, selectedPeriod, selectedVehicle }:
     () => localizeDistribution(stats.autopilotDistribution, autopilot),
     [stats.autopilotDistribution, autopilot, localizeDistribution],
   )
+  // Tesla color names are universal brand names (not translated) — pass an empty
+  // option list so only the UNKNOWN_OPTION sentinel gets localized.
+  const localizedColorDistribution = useMemo(
+    () => localizeDistribution(stats.colorDistribution, []),
+    [stats.colorDistribution, localizeDistribution],
+  )
 
   return (
     <motion.div
@@ -274,7 +280,7 @@ export function StatisticsDashboard({ orders, selectedPeriod, selectedVehicle }:
               <MiniPieChart data={stats.modelDistribution} title={t('modelDistribution')} delay={0} />
               <MiniPieChart data={stats.driveDistribution} title={t('driveDistribution')} delay={0.05} />
               <MiniPieChart data={localizedRangeDistribution} title={t('rangeDistribution')} delay={0.1} />
-              <MiniPieChart data={stats.colorDistribution} title={t('colorDistribution')} delay={0.15} />
+              <MiniPieChart data={localizedColorDistribution} title={t('colorDistribution')} delay={0.15} />
             </div>
           </motion.div>
         </TabsContent>

--- a/src/components/statistics/StatisticsDashboard.tsx
+++ b/src/components/statistics/StatisticsDashboard.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo, useRef } from 'react'
 import { useTranslations } from 'next-intl'
 import { motion } from 'framer-motion'
 import { Order, VehicleType } from '@/lib/types'
-import { calculateStatistics, StatsPeriod, UNKNOWN_COUNTRY } from '@/lib/statistics'
+import { calculateStatistics, StatsPeriod, UNKNOWN_COUNTRY, UNKNOWN_OPTION } from '@/lib/statistics'
 import { useOptions } from '@/hooks/useOptions'
 import { TwemojiEmoji } from '@/components/TwemojiText'
 import { StatCard } from './StatCard'
@@ -47,7 +47,7 @@ export function StatisticsDashboard({ orders, selectedPeriod, selectedVehicle }:
   const t = useTranslations('statistics')
   const tcd = useTranslations('countryDelivery')
   const tCommon = useTranslations('common')
-  const { countries } = useOptions()
+  const { countries, ranges, interiors, autopilot, towHitch, seats } = useOptions()
 
   const tabsRef = useRef<HTMLDivElement>(null)
 
@@ -80,6 +80,52 @@ export function StatisticsDashboard({ orders, selectedPeriod, selectedVehicle }:
   const localizedCountryDistribution = useMemo(
     () => stats.countryDistribution.map(d => ({ ...d, name: resolveCountry(d.name).label })),
     [stats.countryDistribution, resolveCountry]
+  )
+
+  // Distributions emit stable option values (e.g. 'black', 'ja', '5'); map them
+  // to localized labels via useOptions(), which already returns translated labels
+  // for translatable types. The UNKNOWN_OPTION slice is hidden unless it's the
+  // only entry (mirrors MiniPieChart) and otherwise shown as the localized
+  // "unknown" label — kept locale-consistent here rather than in the chart.
+  const localizeDistribution = useCallback(
+    (
+      dist: { name: string; count: number; fill: string }[],
+      optionList: { value: string; label: string }[],
+    ) => {
+      const labelByValue = new Map(optionList.map(o => [o.value.toLowerCase(), o.label]))
+      const hasReal = dist.some(d => d.name !== UNKNOWN_OPTION)
+      return dist
+        .filter(d => d.name !== UNKNOWN_OPTION || !hasReal)
+        .map(d => ({
+          ...d,
+          name:
+            d.name === UNKNOWN_OPTION
+              ? tCommon('unknown')
+              : labelByValue.get(d.name.toLowerCase()) ?? d.name,
+        }))
+    },
+    [tCommon],
+  )
+
+  const localizedRangeDistribution = useMemo(
+    () => localizeDistribution(stats.rangeDistribution, ranges),
+    [stats.rangeDistribution, ranges, localizeDistribution],
+  )
+  const localizedInteriorDistribution = useMemo(
+    () => localizeDistribution(stats.interiorDistribution, interiors),
+    [stats.interiorDistribution, interiors, localizeDistribution],
+  )
+  const localizedTowHitchDistribution = useMemo(
+    () => localizeDistribution(stats.towHitchDistribution, towHitch),
+    [stats.towHitchDistribution, towHitch, localizeDistribution],
+  )
+  const localizedSeatsDistribution = useMemo(
+    () => localizeDistribution(stats.seatsDistribution, seats),
+    [stats.seatsDistribution, seats, localizeDistribution],
+  )
+  const localizedAutopilotDistribution = useMemo(
+    () => localizeDistribution(stats.autopilotDistribution, autopilot),
+    [stats.autopilotDistribution, autopilot, localizeDistribution],
   )
 
   return (
@@ -227,7 +273,7 @@ export function StatisticsDashboard({ orders, selectedPeriod, selectedVehicle }:
             <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
               <MiniPieChart data={stats.modelDistribution} title={t('modelDistribution')} delay={0} />
               <MiniPieChart data={stats.driveDistribution} title={t('driveDistribution')} delay={0.05} />
-              <MiniPieChart data={stats.rangeDistribution} title={t('rangeDistribution')} delay={0.1} />
+              <MiniPieChart data={localizedRangeDistribution} title={t('rangeDistribution')} delay={0.1} />
               <MiniPieChart data={stats.colorDistribution} title={t('colorDistribution')} delay={0.15} />
             </div>
           </motion.div>
@@ -242,11 +288,11 @@ export function StatisticsDashboard({ orders, selectedPeriod, selectedVehicle }:
             transition={{ duration: 0.2 }}
           >
             <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-              <MiniPieChart data={stats.interiorDistribution} title={t('interiorDistribution')} delay={0} />
+              <MiniPieChart data={localizedInteriorDistribution} title={t('interiorDistribution')} delay={0} />
               <MiniPieChart data={stats.wheelsDistribution} title={t('wheelsDistribution')} delay={0.05} />
-              <MiniPieChart data={stats.towHitchDistribution} title={t('towHitchDistribution')} delay={0.1} />
-              <MiniPieChart data={stats.seatsDistribution} title={t('seatsDistribution')} delay={0.15} />
-              <MiniPieChart data={stats.autopilotDistribution} title={t('autopilotDistribution')} delay={0.2} />
+              <MiniPieChart data={localizedTowHitchDistribution} title={t('towHitchDistribution')} delay={0.1} />
+              <MiniPieChart data={localizedSeatsDistribution} title={t('seatsDistribution')} delay={0.15} />
+              <MiniPieChart data={localizedAutopilotDistribution} title={t('autopilotDistribution')} delay={0.2} />
             </div>
           </motion.div>
         </TabsContent>

--- a/src/lib/statistics.ts
+++ b/src/lib/statistics.ts
@@ -20,6 +20,10 @@ const COUNTRY_ALIASES: Record<string, string> = {
 // Sentinel for null/empty/unknown — display layer maps this to a localized label.
 export const UNKNOWN_COUNTRY = '__unknown__'
 
+// Sentinel for option distributions (interior, range, towHitch, seats, autopilot)
+// whose value couldn't be resolved. Display layer maps this to a localized label.
+export const UNKNOWN_OPTION = '__unknown__'
+
 // Returns a stable identifier: lowercase ISO code (e.g. 'de'), the UNKNOWN_COUNTRY
 // sentinel, or the trimmed raw value when no mapping is found. The display layer
 // is responsible for turning this into a localized label.
@@ -63,6 +67,7 @@ export interface OrderStatistics {
   avgOrderToPapers: number | null
   avgPapersToDelivery: number | null
   modelDistribution: { name: string; count: number; fill: string }[]
+  /** `name` is an option value (e.g. 'maximale_reichweite') or the UNKNOWN_OPTION sentinel. Localize at display time via a useOptions() lookup. */
   rangeDistribution: { name: string; count: number; fill: string }[]
   /** `name` is an ISO country code (lowercase, e.g. 'de'), the UNKNOWN_COUNTRY sentinel, or a raw fallback string. Resolve at display time via a useOptions() lookup. */
   countryDistribution: { name: string; count: number; fill: string }[]
@@ -71,10 +76,14 @@ export interface OrderStatistics {
   deliveriesOverTime: { month: string; count: number }[]
   waitTimeDistribution: { range: string; count: number; min: number; max: number }[]
   wheelsDistribution: { name: string; count: number; fill: string }[]
+  /** `name` is an option value (e.g. 'black') or the UNKNOWN_OPTION sentinel. Localize at display time via a useOptions() lookup. */
   interiorDistribution: { name: string; count: number; fill: string }[]
+  /** `name` is an option value (e.g. 'none', 'fsd') or the UNKNOWN_OPTION sentinel. Localize at display time via a useOptions() lookup. */
   autopilotDistribution: { name: string; count: number; fill: string }[]
   driveDistribution: { name: string; count: number; fill: string }[]
+  /** `name` is an option value (e.g. 'ja', 'nein') or the UNKNOWN_OPTION sentinel. Localize at display time via a useOptions() lookup. */
   towHitchDistribution: { name: string; count: number; fill: string }[]
+  /** `name` is an option value (e.g. '5') or the UNKNOWN_OPTION sentinel. Localize at display time via a useOptions() lookup. */
   seatsDistribution: { name: string; count: number; fill: string }[]
   colorDistribution: { name: string; count: number; fill: string }[]
   deliveryLocationDistribution: { name: string; count: number; fill: string }[]
@@ -241,6 +250,24 @@ function normalizeOption<T extends { value: string; label: string }>(
   return trimmed
 }
 
+// Like normalizeOption, but returns the stable option *value* (e.g. 'black', 'ja',
+// '5') instead of the German label, so the display layer can localize it via
+// useOptions(). Used for distributions whose option type has translations.
+function normalizeOptionValue<T extends { value: string; label: string }>(
+  value: string | null | undefined,
+  options: T[],
+  fallback: string = UNKNOWN_OPTION
+): string {
+  if (!value) return fallback
+  const trimmed = value.trim()
+  const byValue = options.find(o => o.value.toLowerCase() === trimmed.toLowerCase())
+  if (byValue) return byValue.value
+  const byLabel = options.find(o => o.label.toLowerCase() === trimmed.toLowerCase())
+  if (byLabel) return byLabel.value
+  // No match — return raw value; display layer shows it verbatim.
+  return trimmed
+}
+
 // Normalize model names (combines Model Y and Model 3 trims)
 function normalizeModel(model: string | null | undefined): string {
   if (!model) return 'Unbekannt'
@@ -368,12 +395,12 @@ export function calculateStatistics(orders: Order[], period?: StatsPeriod, vehic
 
   // Range (Reichweite) distribution - all models (Performance = Max RW, Standard = Standard)
   const RANGE_COLORS: Record<string, string> = {
-    'Maximale Reichweite': 'var(--chart-2)',
-    'Standard': 'var(--chart-3)',
+    'maximale_reichweite': 'var(--chart-2)',
+    'standard': 'var(--chart-3)',
   }
   const rangeCounts: Record<string, number> = {}
   filteredOrders.forEach(order => {
-    const range = normalizeOption(order.range, RANGES, 'Unbekannt')
+    const range = normalizeOptionValue(order.range, RANGES)
     rangeCounts[range] = (rangeCounts[range] || 0) + 1
   })
   const rangeDistribution = Object.entries(rangeCounts)
@@ -477,13 +504,13 @@ export function calculateStatistics(orders: Order[], period?: StatsPeriod, vehic
 
   // Interior distribution (black & white colors, normalized)
   const INTERIOR_COLORS: Record<string, string> = {
-    'Schwarz': '#1a1a1a',
-    'Weiß': '#e5e5e5',
-    'Unbekannt': '#9ca3af',
+    'black': '#1a1a1a',
+    'white': '#e5e5e5',
+    [UNKNOWN_OPTION]: '#9ca3af',
   }
   const interiorCounts: Record<string, number> = {}
   filteredOrders.forEach(order => {
-    const interior = normalizeOption(order.interior, INTERIORS, 'Unbekannt')
+    const interior = normalizeOptionValue(order.interior, INTERIORS)
     interiorCounts[interior] = (interiorCounts[interior] || 0) + 1
   })
   const interiorDistribution = Object.entries(interiorCounts)
@@ -497,7 +524,7 @@ export function calculateStatistics(orders: Order[], period?: StatsPeriod, vehic
   // Autopilot distribution (normalized to labels)
   const autopilotCounts: Record<string, number> = {}
   filteredOrders.forEach(order => {
-    const autopilot = normalizeOption(order.autopilot, AUTOPILOT_OPTIONS, 'Kein')
+    const autopilot = normalizeOptionValue(order.autopilot, AUTOPILOT_OPTIONS, 'none')
     autopilotCounts[autopilot] = (autopilotCounts[autopilot] || 0) + 1
   })
   const autopilotDistribution = Object.entries(autopilotCounts)
@@ -525,7 +552,7 @@ export function calculateStatistics(orders: Order[], period?: StatsPeriod, vehic
   // Tow hitch (AHK) distribution (normalized to labels)
   const towHitchCounts: Record<string, number> = {}
   filteredOrders.forEach(order => {
-    const towHitch = normalizeOption(order.towHitch, TOW_HITCH_OPTIONS, 'Unbekannt')
+    const towHitch = normalizeOptionValue(order.towHitch, TOW_HITCH_OPTIONS)
     towHitchCounts[towHitch] = (towHitchCounts[towHitch] || 0) + 1
   })
   const towHitchDistribution = Object.entries(towHitchCounts)
@@ -539,7 +566,7 @@ export function calculateStatistics(orders: Order[], period?: StatsPeriod, vehic
   // Seats (Sitze) distribution - null treated as 5-Sitzer
   const seatsCounts: Record<string, number> = {}
   filteredOrders.forEach(order => {
-    const seats = normalizeOption(order.seats || '5', SEATS_OPTIONS, '5-Sitzer')
+    const seats = normalizeOptionValue(order.seats || '5', SEATS_OPTIONS, '5')
     seatsCounts[seats] = (seatsCounts[seats] || 0) + 1
   })
   const seatsDistribution = Object.entries(seatsCounts)

--- a/src/lib/statistics.ts
+++ b/src/lib/statistics.ts
@@ -85,6 +85,7 @@ export interface OrderStatistics {
   towHitchDistribution: { name: string; count: number; fill: string }[]
   /** `name` is an option value (e.g. '5') or the UNKNOWN_OPTION sentinel. Localize at display time via a useOptions() lookup. */
   seatsDistribution: { name: string; count: number; fill: string }[]
+  /** `name` is a Tesla brand color name (kept verbatim — universal, not translated) or the UNKNOWN_OPTION sentinel, which the display layer localizes. */
   colorDistribution: { name: string; count: number; fill: string }[]
   deliveryLocationDistribution: { name: string; count: number; fill: string }[]
   vinWeekdayDistribution: { dayOfWeek: number; count: number }[]
@@ -583,7 +584,7 @@ export function calculateStatistics(orders: Order[], period?: StatsPeriod, vehic
     // Look up color label and hex from COLORS constant
     const colorValue = order.color || ''
     const colorInfo = COLORS.find(c => c.value === colorValue || c.label.toLowerCase() === colorValue.toLowerCase())
-    const colorLabel = colorInfo?.label || colorValue || 'Unbekannt'
+    const colorLabel = colorInfo?.label || colorValue || UNKNOWN_OPTION
     const colorHex = colorInfo?.hex || findColorHex(colorValue)
 
     if (!colorCounts[colorLabel]) {


### PR DESCRIPTION
@
## Problem
The **Configuration** and **Equipment** stats tabs showed hardcoded German values regardless of UI language — e.g. in French: *Intérieur* → "Schwarz/Weiß", *Attelage* → "Ja/Nein", *Sièges* → "5-Sitzer", plus *Autonomie* → "Maximale Reichweite" and Autopilot → "Kein".

## Root cause
`normalizeOption()` in `src/lib/statistics.ts` returns the German `.label`, and `MiniPieChart` renders `name` verbatim. Same class of leak fixed for countries in #14, not yet applied to the config distributions.

## Fix
Mirrors the #14 pattern — data layer emits stable identifiers, display layer localizes:
- New `normalizeOptionValue()` helper returns the stable option **value** (`black`, `ja`, `5`, `none`, `maximale_reichweite`) plus an `UNKNOWN_OPTION` sentinel.
- `StatisticsDashboard` maps each value → localized label via `useOptions()` (which already returns translated labels for the translatable types).
- `RANGE_COLORS` / `INTERIOR_COLORS` rekeyed from German label → value so fills survive.
- Preserved semantics: missing autopilot = `none` ("Aucun"), missing seats = `5`. Unknown slice stays hidden unless it is the only entry — now locale-consistent (was keyed on the literal "Unbekannt").

Covers all 5 translatable distributions: **interior, range, towHitch, seats, autopilot**. `normalizeOption` (still used by model/drive), color, and wheels are untouched.

## Verification
- `prisma generate` + `tsc --noEmit`: **0 errors**
- Confirmed `options.{interior,towHitch,seats,range,autopilot}.*` keys exist in `messages/fr.json` (and the shared i18n structure)
- Only runtime consumer of these distributions is the dashboard

Not yet verified live in a browser — happy to do a local run if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@