### PR TITLE
fix(i18n): localize unknown fallback on model/drive/wheels charts

### DIFF
--- a/src/components/statistics/StatisticsDashboard.tsx
+++ b/src/components/statistics/StatisticsDashboard.tsx
@@ -133,6 +133,20 @@ export function StatisticsDashboard({ orders, selectedPeriod, selectedVehicle }:
     () => localizeDistribution(stats.colorDistribution, []),
     [stats.colorDistribution, localizeDistribution],
   )
+  // Trim names (Standard/Premium/…), drive (RWD/AWD) and wheel sizes are also
+  // universal — only their UNKNOWN_OPTION fallback needs localizing.
+  const localizedModelDistribution = useMemo(
+    () => localizeDistribution(stats.modelDistribution, []),
+    [stats.modelDistribution, localizeDistribution],
+  )
+  const localizedDriveDistribution = useMemo(
+    () => localizeDistribution(stats.driveDistribution, []),
+    [stats.driveDistribution, localizeDistribution],
+  )
+  const localizedWheelsDistribution = useMemo(
+    () => localizeDistribution(stats.wheelsDistribution, []),
+    [stats.wheelsDistribution, localizeDistribution],
+  )
 
   return (
     <motion.div
@@ -277,8 +291,8 @@ export function StatisticsDashboard({ orders, selectedPeriod, selectedVehicle }:
             transition={{ duration: 0.2 }}
           >
             <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-              <MiniPieChart data={stats.modelDistribution} title={t('modelDistribution')} delay={0} />
-              <MiniPieChart data={stats.driveDistribution} title={t('driveDistribution')} delay={0.05} />
+              <MiniPieChart data={localizedModelDistribution} title={t('modelDistribution')} delay={0} />
+              <MiniPieChart data={localizedDriveDistribution} title={t('driveDistribution')} delay={0.05} />
               <MiniPieChart data={localizedRangeDistribution} title={t('rangeDistribution')} delay={0.1} />
               <MiniPieChart data={localizedColorDistribution} title={t('colorDistribution')} delay={0.15} />
             </div>
@@ -295,7 +309,7 @@ export function StatisticsDashboard({ orders, selectedPeriod, selectedVehicle }:
           >
             <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
               <MiniPieChart data={localizedInteriorDistribution} title={t('interiorDistribution')} delay={0} />
-              <MiniPieChart data={stats.wheelsDistribution} title={t('wheelsDistribution')} delay={0.05} />
+              <MiniPieChart data={localizedWheelsDistribution} title={t('wheelsDistribution')} delay={0.05} />
               <MiniPieChart data={localizedTowHitchDistribution} title={t('towHitchDistribution')} delay={0.1} />
               <MiniPieChart data={localizedSeatsDistribution} title={t('seatsDistribution')} delay={0.15} />
               <MiniPieChart data={localizedAutopilotDistribution} title={t('autopilotDistribution')} delay={0.2} />

--- a/src/lib/statistics.ts
+++ b/src/lib/statistics.ts
@@ -66,6 +66,7 @@ export interface OrderStatistics {
   avgOrderToDelivery: number | null
   avgOrderToPapers: number | null
   avgPapersToDelivery: number | null
+  /** `name` is a Tesla trim name (kept verbatim — universal, not translated) or the UNKNOWN_OPTION sentinel, which the display layer localizes. */
   modelDistribution: { name: string; count: number; fill: string }[]
   /** `name` is an option value (e.g. 'maximale_reichweite') or the UNKNOWN_OPTION sentinel. Localize at display time via a useOptions() lookup. */
   rangeDistribution: { name: string; count: number; fill: string }[]
@@ -75,11 +76,13 @@ export interface OrderStatistics {
   // New statistics
   deliveriesOverTime: { month: string; count: number }[]
   waitTimeDistribution: { range: string; count: number; min: number; max: number }[]
+  /** `name` is a wheel size (e.g. '18"', kept verbatim — universal) or the UNKNOWN_OPTION sentinel, which the display layer localizes. */
   wheelsDistribution: { name: string; count: number; fill: string }[]
   /** `name` is an option value (e.g. 'black') or the UNKNOWN_OPTION sentinel. Localize at display time via a useOptions() lookup. */
   interiorDistribution: { name: string; count: number; fill: string }[]
   /** `name` is an option value (e.g. 'none', 'fsd') or the UNKNOWN_OPTION sentinel. Localize at display time via a useOptions() lookup. */
   autopilotDistribution: { name: string; count: number; fill: string }[]
+  /** `name` is a drive label (RWD/AWD, kept verbatim — universal) or the UNKNOWN_OPTION sentinel, which the display layer localizes. */
   driveDistribution: { name: string; count: number; fill: string }[]
   /** `name` is an option value (e.g. 'ja', 'nein') or the UNKNOWN_OPTION sentinel. Localize at display time via a useOptions() lookup. */
   towHitchDistribution: { name: string; count: number; fill: string }[]
@@ -223,7 +226,7 @@ function findColorHex(colorName: string): string | null {
 
 // Normalize wheel sizes (e.g., "20", "20\"", "20 Zoll" -> "20\"")
 function normalizeWheels(wheels: string | null | undefined): string {
-  if (!wheels) return 'Unbekannt'
+  if (!wheels) return UNKNOWN_OPTION
   const trimmed = wheels.trim()
   // Extract just the number
   const match = trimmed.match(/(\d{2})/)
@@ -271,7 +274,7 @@ function normalizeOptionValue<T extends { value: string; label: string }>(
 
 // Normalize model names (combines Model Y and Model 3 trims)
 function normalizeModel(model: string | null | undefined): string {
-  if (!model) return 'Unbekannt'
+  if (!model) return UNKNOWN_OPTION
   // Try Model Y trims first
   const normalized = normalizeOption(model, MODEL_Y_TRIMS, '')
   if (normalized) return normalized
@@ -539,7 +542,7 @@ export function calculateStatistics(orders: Order[], period?: StatsPeriod, vehic
   // Drive distribution (normalized)
   const driveCounts: Record<string, number> = {}
   filteredOrders.forEach(order => {
-    const drive = normalizeOption(order.drive, DRIVES, 'Unbekannt')
+    const drive = normalizeOption(order.drive, DRIVES, UNKNOWN_OPTION)
     driveCounts[drive] = (driveCounts[drive] || 0) + 1
   })
   const driveDistribution = Object.entries(driveCounts)


### PR DESCRIPTION
Follow-up to #15. That PR was merged at the color commit, so this last change — the identical German `Unbekannt` fallback fix for the **model**, **drive**, and **wheels** distributions — didn't make it in.

Same minimal pattern: real labels (trim names, RWD/AWD, wheel sizes) are universal and kept verbatim; only the missing-value bucket now emits the `UNKNOWN_OPTION` sentinel and is localized at the display layer via `localizeDistribution` with an empty option list.

`tsc`: 0 errors. No `Unbekannt` fallbacks remain in the stats distributions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)